### PR TITLE
Add UPD port to create command

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ docker create --name=transmission \
 -v <path to downloads>:/downloads \
 -v <path to watch folder>:/watch \
 -e PGID=<gid> -e PUID=<uid> \
--p 9091:9091 -p 51413:51413 \
+-p 9091:9091 -p 51413:51413 -p 51413:51413/udp \
 linuxserver/transmission
 ```
 


### PR DESCRIPTION
UDP port is required otherwise magnetized downloads won't start with UDP trackers.