### PR TITLE
Use proper user to create directories and copy default config.

### DIFF
--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -1,17 +1,8 @@
 #!/usr/bin/with-contenv bash
 
 # make folders
-mkdir -p \
-	/downloads/{complete,incomplete} /watch
+s6-setuidgid abc /bin/bash -c "mkdir -p /downloads/{complete,incomplete} /watch"
 
 # copy config
-[[ ! -f /config/settings.json ]] && cp \
-	/defaults/settings.json /config/settings.json
-
-# permissions
-chown abc:abc \
-	/config/settings.json \
-	/downloads \
-	/downloads/complete \
-	/downloads/incomplete \
-	/watch
+[[ ! -f /config/settings.json ]] && \
+  s6-setuidgid abc /bin/bash -c "cp /defaults/settings.json /config/settings.json"


### PR DESCRIPTION
This prevents issues such as root being unable to write to an NFS mount.
Using "su" to execute as the "abc" user does not work here.

I'm guessing this could (should?) be used in almost all of the linuxserver docker scripts instead of the "mkdir/cp then chown"-flow that's used right now.