### PR TITLE
Fix file not found errors for blocklist update

### DIFF
--- a/root/defaults/blocklist-update.sh
+++ b/root/defaults/blocklist-update.sh
@@ -1,10 +1,10 @@
 #!/usr/bin/with-contenv bash
 
-BLOCKLIST_URL=`jq -r '.["blocklist-url"]' settings.json`
+BLOCKLIST_URL=`jq -r '.["blocklist-url"]' /config/settings.json`
 
 rm /config/blocklists/*
 cd /config/blocklists
-wget -q $BLOCKLIST_URL
+wget -q $BLOCKLIST_URL -O blocklist.gz
 gunzip *.gz
 chmod go+r *
 s6-svc -h /var/run/s6/services/transmission


### PR DESCRIPTION
settings.json needs the full path

wget needs to output a filename otherwise it doesn't always create a .gz file (depending on the blocklist source)