### PR TITLE
Restart needed to reload blocklist

### DIFF
--- a/root/defaults/blocklist-update.sh
+++ b/root/defaults/blocklist-update.sh
@@ -14,7 +14,7 @@ if [ $BLOCKLIST_ENABLED == true ]; then
 			chmod go+r *
 			rm -rf /config/blocklists/*
 			cp /tmp/blocklists/* /config/blocklists
-			s6-svc -h /var/run/s6/services/transmission
+			s6-svc -t /var/run/s6/services/transmission
 		fi
 	fi
 fi

--- a/root/defaults/blocklist-update.sh
+++ b/root/defaults/blocklist-update.sh
@@ -14,7 +14,7 @@ if [ $BLOCKLIST_ENABLED == true ]; then
 			chmod go+r *
 			rm -rf /config/blocklists/*
 			cp /tmp/blocklists/* /config/blocklists
-			s6-svc -t /var/run/s6/services/transmission
+			s6-svc -k /var/run/s6/services/transmission
 		fi
 	fi
 fi


### PR DESCRIPTION
When a new blocklist has been downloaded and extracted, transmission needs to restart to generate a new blocklist.bin file from the source file.

The end result of this script should be a blocklists folder containing 2 files:
blocklist
blocklist.bin