### PR TITLE
add openssl to installed packages

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,7 @@ RUN \
  apk add --no-cache \
 	curl \
 	jq \
+	openssl \
 	p7zip \
 	tar \
 	transmission-cli \


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

`openssl` is required for the blocklist updater script to support https uri's.

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

+ closes #29