### PR TITLE
Added default config for RPC Host Whitelist (false).

### DIFF
--- a/root/defaults/settings.json
+++ b/root/defaults/settings.json
@@ -43,6 +43,8 @@
     "rpc-authentication-required": false,
     "rpc-bind-address": "0.0.0.0",
     "rpc-enabled": true,
+    "rpc-host-whitelist": "",
+    "rpc-host-whitelist-enabled": false, 
     "rpc-password": "{1ddd3f1f6a71d655cde7767242a23a575b44c909n5YuRT.f",
     "rpc-port": 9091,
     "rpc-url": "/transmission/",


### PR DESCRIPTION
I wasn't able to use transmission via the WebUI with the latest image, it seems related to a new RPC Host Whitelist config that is missing from your default config. I was getting a bunch of segfaults related to transmission...

See related dockerized transmission images:

https://github.com/haugene/docker-transmission-openvpn/issues/418

https://github.com/haugene/docker-transmission-openvpn/commit/c0b959e1681641cbebddc99cf80401d8b2e63203


