### PR TITLE
Don't create 'complete' & 'incomplete' addtional download folders

### DIFF
--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -2,7 +2,7 @@
 
 # make folders
 mkdir -p \
-	/downloads/{complete,incomplete} /watch
+	/downloads /watch
 
 # copy config
 [[ ! -f /config/settings.json ]] && cp \
@@ -17,8 +17,6 @@ chown abc:abc \
 	/config/settings.json \
 	/config/blocklist-update.sh \
 	/downloads \
-	/downloads/complete \
-	/downloads/incomplete \
 	/watch
 
 chmod 755 /config/blocklist-update.sh


### PR DESCRIPTION
Get rid of 'complete' & 'incomplete' mkdirs to let users choose to their likings in transmission's config.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  That you have made a branch in your fork, we'd rather not merge from your master -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!---  -->

##  Thanks, team linuxserver.io

