### PR TITLE
Add findutils

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ RUN \
 	rsync \
 	tar \
 	unrar \
-	unzip && \
+	unzip \
+  findutils && \
  apk add --no-cache \
 	--repository http://nl.alpinelinux.org/alpine/edge/main \
 	transmission-cli \

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,7 +17,7 @@ RUN \
 	tar \
 	unrar \
 	unzip \
-  findutils && \
+	findutils && \
  apk add --no-cache \
 	--repository http://nl.alpinelinux.org/alpine/edge/main \
 	transmission-cli \


### PR DESCRIPTION
This will add the GNU find command to the shell so automated unrar scripts can be added to transmission. By default, the busybox find command does not have `-execdir` options which makes it a little difficult to do a simple unrar on completion action.