### PR TITLE
remove logic that sets auth to false to protect custom setups 

### DIFF
--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -16,8 +16,6 @@ if [ ! -z "$USER" ] && [ ! -z "$PASS" ]; then
 	sed -i '/rpc-authentication-required/c\    "rpc-authentication-required": true,' /config/settings.json
 	sed -i "/rpc-username/c\    \"rpc-username\": \"$USER\"," /config/settings.json
 	sed -i "/rpc-password/c\    \"rpc-password\": \"$PASS\"," /config/settings.json
-else
-	sed -i '/rpc-authentication-required/c\    "rpc-authentication-required": false,' /config/settings.json
 fi
 
 # permissions


### PR DESCRIPTION
Title, I get the usage, but I did not think about people that are not using ENV, their custom setting would get blown away. 

If users want to revert from auth after using env they will need to manually modify the config file themselves. 