### PR TITLE
Adding a script to autoremove torrents that have finished

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,8 +64,11 @@ docker create \
   -e PGID=1000 \
   -e TZ=Europe/London \
   -e TRANSMISSION_WEB_HOME=/combustion-release/ `#optional` \
+  -e AUTOREMOVE=yes `#optional` \
   -e USER=username `#optional` \
   -e PASS=password `#optional` \
+  -e AUTHENABLE=yes `#optional` \
+  -e CRONDATE=monthly `#optional` \
   -p 9091:9091 \
   -p 51413:51413 \
   -p 51413:51413/udp \
@@ -93,8 +96,11 @@ services:
       - PGID=1000
       - TZ=Europe/London
       - TRANSMISSION_WEB_HOME=/combustion-release/ #optional
+      - AUTOREMOVE=yes `#optional`
       - USER=username #optional
       - PASS=password #optional
+      - AUTHENABLE=yes `#optional`
+      - CRONDATE=monthly `#optional`
     volumes:
       - <path to data>:/config
       - <path to downloads>:/downloads
@@ -119,8 +125,11 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PGID=1000` | for GroupID - see below for explanation |
 | `-e TZ=Europe/London` | Specify a timezone to use EG Europe/London. |
 | `-e TRANSMISSION_WEB_HOME=/combustion-release/` | Specify an alternative UI options are `/combustion-release/`, `/transmission-web-control/`, and `/kettu/` . |
+| `-e AUTOREMOVE=yes` | Active a script to autoremove torrents when these have finished |
 | `-e USER=username` | Specify an optional username for the interface |
 | `-e PASS=password` | Specify an optional password for the interface |
+| `-e AUTHENABLE=yes` | When **user** and **pass** have been defined and **autoremove ** is enabled, this parameter has to be activated. |
+| `-e CRONDATE=monthly` | Specify when the torrents have to be removed. Options are: **monthly**, **weekly** or **daily**. **Monthly** is defined by default. |
 | `-v /config` | Where transmission should store config files and logs. |
 | `-v /downloads` | Local path for downloads. |
 | `-v /watch` | Watch folder for torrent files. |

--- a/root/defaults/autoremove.sh
+++ b/root/defaults/autoremove.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+
+#Path to the script
+SCRIPT=/defaults/transmission_remove_finished
+
+#Verify if autoremove is activated
+if [[ $AUTOREMOVE = yes ]]; then
+	#Verify if the authentication is activated
+	if [[ $AUTHENABLE = yes ]] || [[ ! -z USER ]] && [[ ! -z PASS ]]; then
+		curl -L "https://gist.githubusercontent.com/tzinm/003a062ee985eb1fdd22bab6113486d6/raw/5e3ed23dbfec61aa98e68b1464148c995f61034c/docker_transmission_remove_finished.sh" > $SCRIPT
+		chmod 700 $SCRIPT
+	elif [ -z $AUTHENABLE ] || [ $AUTHENABLE = no ]; then
+		curl -L "https://gist.githubusercontent.com/tzinm/003a062ee985eb1fdd22bab6113486d6/raw/5e3ed23dbfec61aa98e68b1464148c995f61034c/docker_transmission_remove_finished.sh" > $SCRIPT
+		chmod 700 $SCRIPT
+		sed -i -e 's/^SERVER/#SERVER/g' -e 's/$SERVER//g' $SCRIPT
+	fi
+	#Stablish when the script runs
+	if [[ $CRONDATE = daily ]]; then
+		mv $SCRIPT /etc/periodic/daily/.
+	elif [[ $CRONDATE = weekly ]]; then
+		mv $SCRIPT /etc/periodic/weekly/.
+	elif [[ $CRONDATE = monthly ]]; then
+		mv $SCRIPT /etc/periodic/monthly/.
+	else
+		CRONDATE=monthly
+		mv $SCRIPT /etc/periodic/monthly.
+	fi
+fi
+
+#Delete the line in crontab corresponding to this script
+sed -i '/@reboot/d' /etc/crontabs/root 2>/dev/null
+
+#Autodeleting the script
+rm -rf $0

--- a/root/etc/crontabs/root
+++ b/root/etc/crontabs/root
@@ -8,3 +8,6 @@
 
 # run daily blocklist update
 0 3 * * * /config/blocklist-update.sh 2>&1
+
+#run autoremove script when we create our container
+@reboot /defaults/autoremove.sh


### PR DESCRIPTION

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	
## Script to autoremove torrents

Like the description says, I´ve added a script that remove finished torrents. I have made change in the README.md, explaining how to configure the new variables if you want to run this script. This script is optional, if you choose AUTOREMOVE=no or you don´t add this variable, this script doesn´t run.

Additionally, the user can choose when it runs, adding the script to the correcto directory.


##  Thanks, team linuxserver.io

