### PR TITLE
Allow for custom Blocklist update scripts located in /config

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -68,11 +68,15 @@ app_setup_block: |
 
   The automatic update is a shell script that downloads a blocklist from the url stored in the settings.json, gunzips it, and restarts the transmission daemon.
 
+
+  If a custom shell script located at `/config/blocklist-update.sh` exsists it will takes precedent over the default script and will not use the `blocklist-url`. This is usefull if you want to create a custom script to concatinate multiple blocklists from multiple URLs.
+
   The automatic update will run once a day at 3am local server time.
 
 # changelog
 changelogs:
 
+  - { date: "25.04.20:", desc: "Updated blocklist-update.sh to also run custom scripts located in the /config folder." }
   - { date: "30.03.20:", desc: "Internalize blocklist-update.sh." }
   - { date: "29.03.20:", desc: "Update auth info in readme." }
   - { date: "19.12.19:", desc: "Rebasing to alpine 3.11." }

--- a/root/app/blocklist-update.sh
+++ b/root/app/blocklist-update.sh
@@ -2,19 +2,39 @@
 
 BLOCKLIST_ENABLED=`jq -r '.["blocklist-enabled"]' /config/settings.json`
 BLOCKLIST_URL=`jq -r '.["blocklist-url"]' /config/settings.json | sed 's/\&amp;/\&/g'`
+SCRIPT_DEBUG=false
 
-if [ $BLOCKLIST_ENABLED == true ]; then
+# Exit if Block list is not enabled
+[ $BLOCKLIST_ENABLED == true ] || exit 0
+
+# Check if custom script exists in config folder
+if [ -e /config/blocklist-update.sh ]; then
+	[ $SCRIPT_DEBUG == true ] && echo "Custom script found Running [/config/update-blocklist.sh]"
+	/config/blocklist-update.sh
+	ret=$((ret + $?))
+	[ $SCRIPT_DEBUG == true ] && echo "Custom script at [/config/blocklist-update.sh] exited with [$ret]"
+else
+	[ $SCRIPT_DEBUG == true ] && echo "Running [/app/update-blocklist.sh]"
 	mkdir -p /tmp/blocklists
 	rm -rf /tmp/blocklists/*
 	cd /tmp/blocklists
 	wget -q -O blocklist.gz "$BLOCKLIST_URL"
-	if [ $? == 0 ]; then
+	ret=$((ret + $?))
+	[ $SCRIPT_DEBUG == true ] && echo "blocklist at [$BLOCKLIST_URL] downloaded exited with [$ret]"
+	if [ $ret == 0 ]; then
 		gunzip *.gz
-		if [ $? == 0 ]; then
+		ret=$((ret + $?))
+		[ $SCRIPT_DEBUG == true ] && echo "Gunzip extracted [$(ls)] and exited with [$ret]"
+		if [ $ret == 0 ]; then
 			chmod go+r *
 			rm -rf /config/blocklists/*
 			cp /tmp/blocklists/* /config/blocklists
-			s6-svc -t /var/run/s6/services/transmission
+			[ $SCRIPT_DEBUG == true ] && echo "[$(ls /tmp/blocklists/*)] copied to [/config/blocklists]"
 		fi
 	fi
 fi
+
+
+[ $SCRIPT_DEBUG == true ] && echo "Transmission will restart if return values [$ret] is equal to \"0\""
+# Restart Transmission after blocklist update
+[ $ret == 0 ] && s6-svc -t /var/run/s6/services/transmission


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
After the pull request  #99 where the update script is internalized it is hard to have a custom script run like before. I have a script that concatenates multiple URLs from different sources into one file. This pull request will add support for executing `/config/blocklist-update.sh` if it exists. If the custom script doesn't exist in the `/config` folder the original script is executed. 

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]
	

<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  --> 
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

We welcome all PR’s though this doesn’t guarantee it will be accepted.

## Description:
<!--- Describe your changes in detail -->
I have modified the `/root/app/blocklist-update.sh` script to allow for custom scripts located in the `/config` folder. After the latest change where this script was internalized, I am no longer able to execute a custom script to update the blocklists for transmission. There are multiple blocklists that can be useful, by allowing custom scripts to be executed it will allow users to download multiple blocklists and apply them to Transmission.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This script doesn't change any default functionality but adds the option to run user scripts to configure the blocklists. 
## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Yes, I have added a debug message that can be toggled, default off. I have also tested with custom scripts and using the existing functionality of using a `blocklist-url` from the `settings.json`.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
