### PR TITLE
Declare forwarding of both TCP and UDP in EXPOSE statement

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -63,5 +63,5 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-EXPOSE 9091 51413
+EXPOSE 9091 51413/tcp 51413/udp
 VOLUME /config /downloads /watch

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -62,6 +62,5 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-EXPOSE 9091 51413
+EXPOSE 9091 51413/tcp 51413/udp
 VOLUME /config /downloads /watch
-

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -62,6 +62,5 @@ RUN \
 COPY root/ /
 
 # ports and volumes
-EXPOSE 9091 51413
+EXPOSE 9091 51413/tcp 51413/udp
 VOLUME /config /downloads /watch
-


### PR DESCRIPTION
To go in line with the README I think it would be appropriate to
inform directly in the Dockerfile that port 51413 expects both TCP
and UDP traffic to be forwarded.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo in code or documentation in the README please file an issue and let us sort it out we do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X] I have read the [contributing](https://github.com/linuxserver/docker-transmission/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Just a small change where I add information in the Dockerfile that it is both TCP and UDP traffic that should be forwarded to port 51413.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
It becomes more clear what needs to be forwarded in case you are only reading the Dockerfile. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I built the image locally, as per instructions in the README, and then launched the container with just the `-P` flag which then automatically forwarded three ports:

```
0.0.0.0:32771->9091/tcp
0.0.0.0:32769->51413/udp
0.0.0.0:32770->51413/tcp
```

Even though he host ports are random (see explanation in source below) it shows that Docker picks up this addition correctly. 


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://docs.docker.com/engine/reference/builder/#expose
