### PR TITLE
wait until the transmission-daemon terminates properly

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -79,6 +79,7 @@ app_setup_block: |
 # changelog
 changelogs:
 
+  - { date: "09.07.21:", desc: "Wait for the transmission-daemon termination after a caught sigterm" }
   - { date: "06.03.21:", desc: "Add Flood for Transmission as a UI option" }
   - { date: "23.01.21:", desc: "Rebasing to alpine 3.13." }
   - { date: "02.11.20:", desc: "Add ca-certificates package to allow connecting to https trackers." }

--- a/root/etc/services.d/transmission/run
+++ b/root/etc/services.d/transmission/run
@@ -2,11 +2,15 @@
 
 _term() {
   echo "Caught SIGTERM signal!"
+  echo "Tell the transmission session to shut down."
+  pid=$(pidof transmission-daemon)
   if [ ! -z "$USER" ] && [ ! -z "$PASS" ]; then
     /usr/bin/transmission-remote -n "$USER":"$PASS" --exit
   else
     /usr/bin/transmission-remote --exit
   fi
+  # terminate when the transmission-daemon process dies
+  tail --pid=${pid} -f /dev/null
 }
 
         trap _term SIGTERM


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-transmission/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
We should wait for the termination of the transmission-daemon before the s6 service issues a sigterm to all remaining processes.
Without this delay the s6 sigterms are issued right after the RPC 'transmission-remote --exit'. This leaves not time to properly save the settings.json file, stats.json file, all resume files and showing the closing message 'Closing transmission session... done'.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This PR closes #80.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
docker-compose.yml:
```
version: '2'
services:
  transmission:
    image: linuxserver/transmission
    container_name: transmission
    environment:
      - PUID=1000
      - PGID=1000
      - TZ=Europe/London
      - TRANSMISSION_WEB_HOME=/transmission-web-control/
      - USER=username
      - PASS=password
    volumes:
      - /root/transmission_config:/config
      - /root/Downloads/transmission:/downloads
      - /root/Downloads/transmission/watch:/watch
    ports:
      - 9091:9091
      - 51413:51413
      - 51413:51413/udp
```

Build:
```
# git clone https://github.com/linuxserver/docker-transmission.git
# cd docker-transmission
# docker build \
  --no-cache \
  --pull \
  -t linuxserver/transmission:latest .
```

Start:
```
# docker-compose up -d
```

Log after issuing `docker-compose down` without the fix:
```
# docker logs -f transmission
...
Caught SIGTERM signal!
localhost:9091/transmission/rpc/ responded: "success"
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
[s6-finish] waiting for services.
[s6-finish] sending all processes the TERM signal.
[2021-07-09 00:47:24.210] Reloading settings from "/config" (/home/buildozer/aports/community/transmission/src/transmission-3.00/daemon/daemon.c:592)
[2021-07-09 00:47:24.210] RPC Server Serving RPC and Web requests on 0.0.0.0:9091/transmission/ (/home/buildozer/aports/community/transmission/src/transmission-3.00/libtransmission/rpc-server.c:1243)
[2021-07-09 00:47:24.210] RPC Server Password required (/home/buildozer/aports/community/transmission/src/transmission-3.00/libtransmission/rpc-server.c:1254)
[2021-07-09 00:47:24.210] Saved "/config/settings.json" (/home/buildozer/aports/community/transmission/src/transmission-3.00/libtransmission/variant.c:1221)
[2021-07-09 00:47:24.210] DHT Not saving nodes, DHT not ready (/home/buildozer/aports/community/transmission/src/transmission-3.00/libtransmission/tr-dht.c:445)
[2021-07-09 00:47:24.210] Port Forwarding Stopped (/home/buildozer/aports/community/transmission/src/transmission-3.00/libtransmission/port-forwarding.c:196)
Closing transmission session... done.
[s6-finish] sending all processes the KILL signal and exiting.

```

Log after issuing `docker-compose down` with the fix:
```
...
Caught SIGTERM signal!
Tell the transmission session to shut down.
localhost:9091/transmission/rpc/ responded: "success"
Closing transmission session... done.
[2021-07-09 00:51:07.671] Saved "/config/settings.json" (/home/buildozer/aports/community/transmission/src/transmission-3.00/libtransmission/variant.c:1221)
[2021-07-09 00:51:07.671] DHT Not saving nodes, DHT not ready (/home/buildozer/aports/community/transmission/src/transmission-3.00/libtransmission/tr-dht.c:445)
[2021-07-09 00:51:07.671] Port Forwarding Stopped (/home/buildozer/aports/community/transmission/src/transmission-3.00/libtransmission/port-forwarding.c:196)
[cont-finish.d] executing container finish scripts...
[cont-finish.d] done.
[s6-finish] waiting for services.
[s6-finish] sending all processes the TERM signal.
[s6-finish] sending all processes the KILL signal and exiting.
```


Important line in the logs when the saving occurs:
`... Saved "/config/settings.json" ...`

Without the fix the old settings get reloaded right after the TERM signal by the S6 service.
This prevents saving changed settings from the Web-Interface:
`... Reloading settings from "/config" ...`

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/linuxserver/docker-transmission/issues/80#issuecomment-876749381