### PR TITLE
Update 20-config to allow PEERPORT setting via environmental variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -156,7 +156,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PASS=password` | Specify an optional password for the interface |
 | `-e WHITELIST=iplist` | Specify an optional list of comma separated ip whitelist. Fill rpc-whitelist setting. |
 | `-e HOST_WHITELIST=dnsnane list` | Specify an optional list of comma separated dns name whitelist. Fill rpc-host-whitelist setting. |
-| `-e PEERPORT=51413` | Specify an optional alternative port for Tranmission to listen for TCP/UDP connections on.. Fill peer-port and disables peer-port-random-on-start settings. |
+| `-e PEERPORT=51413` | Specify an optional alternative port for Tranmission to listen for TCP/UDP connections on. Fill peer-port and disables peer-port-random-on-start settings. |
 | `-v /config` | Where transmission should store config files and logs. |
 | `-v /downloads` | Local path for downloads. |
 | `-v /watch` | Watch folder for torrent files. |

--- a/README.md
+++ b/README.md
@@ -103,6 +103,7 @@ services:
       - PASS=password #optional
       - WHITELIST=iplist #optional
       - HOST_WHITELIST=dnsnane list #optional
+      - PEERPORT=51413 #optional
     volumes:
       - <path to data>:/config
       - <path to downloads>:/downloads
@@ -127,6 +128,7 @@ docker run -d \
   -e PASS=password `#optional` \
   -e WHITELIST=iplist `#optional` \
   -e HOST_WHITELIST=dnsnane list `#optional` \
+  -e PEERPORT=51413 `#optional` \
   -p 9091:9091 \
   -p 51413:51413 \
   -p 51413:51413/udp \
@@ -154,6 +156,7 @@ Container images are configured using parameters passed at runtime (such as thos
 | `-e PASS=password` | Specify an optional password for the interface |
 | `-e WHITELIST=iplist` | Specify an optional list of comma separated ip whitelist. Fill rpc-whitelist setting. |
 | `-e HOST_WHITELIST=dnsnane list` | Specify an optional list of comma separated dns name whitelist. Fill rpc-host-whitelist setting. |
+| `-e PEERPORT=51413` | Specify an optional alternative port for Tranmission to listen for TCP/UDP connections on.. Fill peer-port and disables peer-port-random-on-start settings. |
 | `-v /config` | Where transmission should store config files and logs. |
 | `-v /downloads` | Local path for downloads. |
 | `-v /watch` | Watch folder for torrent files. |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -44,6 +44,7 @@ opt_param_env_vars:
   - { env_var: "USER", env_value: "username", desc: "Specify an optional username for the interface" }
   - { env_var: "PASS", env_value: "password", desc: "Specify an optional password for the interface" }
   - { env_var: "WHITELIST", env_value: "iplist", desc: "Specify an optional list of comma separated ip whitelist. Fill rpc-whitelist setting."}
+  - { env_var: "PEERPORT", env_value: "peerport", desc: "Specify an optional port for torrent TCP/UDP connections. Fill peer-port setting."}
   - { env_var: "HOST_WHITELIST", env_value: "dnsnane list", desc: "Specify an optional list of comma separated dns name whitelist. Fill rpc-host-whitelist setting."}
 opt_param_usage_include_vols: false
 opt_param_usage_include_ports: false
@@ -75,6 +76,10 @@ app_setup_block: |
   Use `WHITELIST` to enable a list of ip as whitelist. This enable support for `rpc-whitelist`. When `WHITELIST` is empty support for whitelist is disabled.
 
   Use `HOST_WHITELIST` to enable an list of dns names as host-whitelist. This enable support for `rpc-host-whitelist`. When `HOST_WHITELIST` is empty support for host-whitelist is disabled.
+  
+  ## Use alternative Transmission torrent ports
+  
+  Use `PEERPORT` to specify the port(s) Transmission should listen on.  This disables random port selection.  This should be the same as the port mapped in your docker configuration.
 
 # changelog
 changelogs:

--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -34,6 +34,15 @@ else
 	sed -i "/\"rpc-host-whitelist\"/c\    \"rpc-host-whitelist\": \"$HOST_WHITELIST\"," /config/settings.json
 fi
 
+if [ ! -z "${PEERPORT}" ]; then
+    sed -i "/\"peer-port\"/c\    \"peer-port\": ${PEERPORT}," /config/settings.json
+    sed -i '/peer-port-random-on-start/c\     "peer-port-random-on-start": false,' /config/settings.json
+fi
+
+if [ ! -z "${WEBUI}" ]; then
+    sed -i "/\"rpc-port\"/c\    \"rpc-port\": ${WEBUI}," /config/settings.json
+fi
+
 
 # permissions
 chown abc:abc \

--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -39,10 +39,6 @@ if [ ! -z "${PEERPORT}" ]; then
     sed -i '/peer-port-random-on-start/c\     "peer-port-random-on-start": false,' /config/settings.json
 fi
 
-if [ ! -z "${WEBUI}" ]; then
-    sed -i "/\"rpc-port\"/c\    \"rpc-port\": ${WEBUI}," /config/settings.json
-fi
-
 
 # permissions
 chown abc:abc \


### PR DESCRIPTION
The addition of $PEERPORT and $WEBUI checks would allow users to specify these ports via environmental variables, and add flexibility, particularly if users run multiple instances.



[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [X ] I have read the [contributing](https://github.com/linuxserver/docker-transmission/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
Adds ability to specify ports for the WEBUI (RPC) and listening port via environmental variables.

## Benefits of this PR and context:
Adds flexibility, simplifies setup.

## How Has This Been Tested?
Tested locally.  Only effect is to /config/settings.json, and only if the environmental variables are set.


## Source / References:
https://github.com/linuxserver/docker-transmission/issues/179
