### PR TITLE
Enables the transmission-web-control "original UI"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -47,6 +47,11 @@ RUN \
 	/tmp/twc.tar.gz -C \
 	/tmp/twctemp --strip-components=1 && \
  mv /tmp/twctemp/src /transmission-web-control && \
+ # Enables the original UI button in transmission-web-control
+ ln -s /usr/share/transmission/web/style /transmission-web-control && \
+ ln -s /usr/share/transmission/web/images /transmission-web-control && \
+ ln -s /usr/share/transmission/web/javascript /transmission-web-control && \
+ ln -s /usr/share/transmission/web/index.html /transmission-web-control/index.original.html && \
  mkdir -p /kettu && \
  curl -o \
 	/tmp/kettu.tar.gz -L \

--- a/Dockerfile.aarch64
+++ b/Dockerfile.aarch64
@@ -47,6 +47,11 @@ RUN \
 	/tmp/twc.tar.gz -C \
 	/tmp/twctemp --strip-components=1 && \
  mv /tmp/twctemp/src /transmission-web-control && \
+ # Enables the original UI button in transmission-web-control
+ ln -s /usr/share/transmission/web/style /transmission-web-control && \
+ ln -s /usr/share/transmission/web/images /transmission-web-control && \
+ ln -s /usr/share/transmission/web/javascript /transmission-web-control && \
+ ln -s /usr/share/transmission/web/index.html /transmission-web-control/index.original.html && \
  mkdir -p /kettu && \
  curl -o \
 	/tmp/kettu.tar.gz -L \

--- a/Dockerfile.armhf
+++ b/Dockerfile.armhf
@@ -47,6 +47,11 @@ RUN \
 	/tmp/twc.tar.gz -C \
 	/tmp/twctemp --strip-components=1 && \
  mv /tmp/twctemp/src /transmission-web-control && \
+ # Enables the original UI button in transmission-web-control
+ ln -s /usr/share/transmission/web/style /transmission-web-control && \
+ ln -s /usr/share/transmission/web/images /transmission-web-control && \
+ ln -s /usr/share/transmission/web/javascript /transmission-web-control && \
+ ln -s /usr/share/transmission/web/index.html /transmission-web-control/index.original.html && \
  mkdir -p /kettu && \
  curl -o \
 	/tmp/kettu.tar.gz -L \


### PR DESCRIPTION
Transmission-web-control has a button to show the original UI. To enable it, symlinks must be made between the default web folder and the TWC folder.

<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-transmission/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Transmission-web-control has a button to show the original UI. To enable it, symlinks must be made between the default web folder and the TWC folder. I've added this symlink code for all Dockerfiles.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
Currently, clicking on the "Original UI" button returns a 404. This fixes this.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Three tests :
- I have tested it with a script
- I have tested it in a Dockerfile for an Home Assistant addon based on this image : https://github.com/alexbelgium/hassio-addons/tree/master/transmission
- This is also already used in other Transmission docker images, such as this one : https://github.com/haugene/docker-transmission-openvpn/blob/master/Dockerfile

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
