### PR TITLE
Default directories are created only if needed

### DIFF
--- a/root/etc/cont-init.d/20-config
+++ b/root/etc/cont-init.d/20-config
@@ -1,49 +1,37 @@
 #!/usr/bin/with-contenv bash
 
-# make folders
-mkdir -p \
-	/downloads/{complete,incomplete} /watch
+# Copy settings
+cp -n /defaults/settings.json /config/settings.json
+SETTINGS=$(< /config/settings.json)
+DEFAULTS=$(< /defaults/settings.json)
 
-# copy config
-[[ ! -f /config/settings.json ]] && cp \
-	/defaults/settings.json /config/settings.json
+# Set directories
+SETTINGS=$(jq --arg key "download-dir" --argjson defaults "$DEFAULTS" -r '.[$key]=([.[$key], $defaults[$key]] | map(select(. | length > 0))[0])' <<< $SETTINGS)
+SETTINGS=$(jq --arg key "incomplete-dir" --argjson defaults "$DEFAULTS" -r '.[$key]=([.[$key], $defaults[$key]] | map(select(. | length > 0))[0])' <<< $SETTINGS)
+SETTINGS=$(jq --arg key "watch-dir" --argjson defaults "$DEFAULTS" -r '.[$key]=([.[$key], $defaults[$key]] | map(select(. | length > 0))[0])' <<< $SETTINGS)
 
-if [ ! -z "$USER" ] && [ ! -z "$PASS" ]; then
-	sed -i '/rpc-authentication-required/c\    "rpc-authentication-required": true,' /config/settings.json
-	sed -i "/rpc-username/c\    \"rpc-username\": \"$USER\"," /config/settings.json
-	sed -i "/rpc-password/c\    \"rpc-password\": \"$PASS\"," /config/settings.json
-else
-	sed -i '/rpc-authentication-required/c\    "rpc-authentication-required": false,' /config/settings.json
-	sed -i "/rpc-username/c\    \"rpc-username\": \"$USER\"," /config/settings.json
-	sed -i "/rpc-password/c\    \"rpc-password\": \"$PASS\"," /config/settings.json
-fi
+# Set authentication
+SETTINGS=$(jq --arg value "$USER" -r '."rpc-username"=$value' <<< $SETTINGS)
+SETTINGS=$(jq --arg value "$PASS" -r '."rpc-password"=$value' <<< $SETTINGS)
+SETTINGS=$(jq -r '."rpc-authentication-required"=((."rpc-username" | length > 0) and (."rpc-password" | length > 0))' <<< $SETTINGS)
 
-if [ ! -z "$WHITELIST" ]; then
-	sed -i '/rpc-whitelist-enabled/c\    "rpc-whitelist-enabled": true,' /config/settings.json
-	sed -i "/\"rpc-whitelist\"/c\    \"rpc-whitelist\": \"$WHITELIST\"," /config/settings.json
-else
-	sed -i '/rpc-whitelist-enabled/c\    "rpc-whitelist-enabled": false,' /config/settings.json
-	sed -i "/\"rpc-whitelist\"/c\    \"rpc-whitelist\": \"$WHITELIST\"," /config/settings.json
-fi
+# Set whitelist
+SETTINGS=$(jq --arg value "$WHITELIST" -r '."rpc-whitelist"=$value' <<< $SETTINGS)
+SETTINGS=$(jq -r '."rpc-whitelist-enabled"=(."rpc-whitelist" | length > 0)' <<< $SETTINGS)
 
-if [ ! -z "$HOST_WHITELIST" ]; then
-	sed -i '/rpc-host-whitelist-enabled/c\    "rpc-host-whitelist-enabled": true,' /config/settings.json
-	sed -i "/\"rpc-host-whitelist\"/c\    \"rpc-host-whitelist\": \"$HOST_WHITELIST\"," /config/settings.json
-else
-	sed -i '/rpc-host-whitelist-enabled/c\    "rpc-host-whitelist-enabled": false,' /config/settings.json
-	sed -i "/\"rpc-host-whitelist\"/c\    \"rpc-host-whitelist\": \"$HOST_WHITELIST\"," /config/settings.json
-fi
+# Set host whitelist
+SETTINGS=$(jq --arg value "$HOST_WHITELIST" -r '."rpc-host-whitelist"=$value' <<< $SETTINGS)
+SETTINGS=$(jq -r '."rpc-host-whitelist-enabled"=(."rpc-host-whitelist" | length > 0)' <<< $SETTINGS)
 
-if [ ! -z "${PEERPORT}" ]; then
-    sed -i "/\"peer-port\"/c\    \"peer-port\": ${PEERPORT}," /config/settings.json
-    sed -i '/peer-port-random-on-start/c\     "peer-port-random-on-start": false,' /config/settings.json
-fi
+# Set peer port
+SETTINGS=$(jq --arg value "$PEERPORT" -r '."peer-port"=([$value, ."peer-port"] | map(select(. | length > 0))[0] | tonumber)' <<< $SETTINGS)
+SETTINGS=$(jq -r '."peer-port-random-on-start"=(."peer-port" | length == 0)' <<< $SETTINGS)
 
+# Creates directories
+install -o abc -g abc -d "$(jq -r '."download-dir"' <<< $SETTINGS)"
+install -o abc -g abc -d "$(jq -r '."incomplete-dir"' <<< $SETTINGS)"
+install -o abc -g abc -d "$(jq -r '."watch-dir"' <<< $SETTINGS)"
 
-# permissions
-chown abc:abc \
-	/config/settings.json \
-	/downloads \
-	/downloads/complete \
-	/downloads/incomplete \
-	/watch
+# Save configuration
+echo $SETTINGS > /config/settings.json
+chown abc:abc config/settings.json


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-transmission/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
The objective of this change is to avoid the creation of the different default directories: for downloads, incomplete downloads, and the watch folder.
Indeed, even if the user has defined their directories, the default ones are annoyingly always created.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This change checks if there is already an existing `/config/settings.json` file and if yes, uses the configured directories.
If there are no directories configured, then values for the directories defined in `/defaults/settings.json` are taken.

Moreover, the file has been simplified to be more readable and using the `jq` command (which is installed anyway) instead of less safe `sed` replacements.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Built with my own CI/CD pipeline on Azure DevOps and deployed on my test rig.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
