### PR TITLE
remove forced watch-dir from run

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/svc-transmission/run
+++ b/root/etc/s6-overlay/s6-rc.d/svc-transmission/run
@@ -3,4 +3,4 @@
 
 s6-notifyoncheck -d -n 300 -w 1000 -c "nc -z localhost 9091" \
     s6-setuidgid abc /usr/bin/transmission-daemon \
-    -g /config -c /watch -f
+    -g /config -f


### PR DESCRIPTION
currently, our run command specific -c /watch which overrides the watch-dir setting in settings.json no matter how it is set. Removing this will hopefully allow users to manually set the watch-dir, much like we can set incomplete-dir, etc. 

I havent tested anything yet, so this will stay open until i or someone does.