### PR TITLE
add optional vars for custom complete/incomplete paths

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,12 @@ Use `HOST_WHITELIST` to enable an list of dns names as host-whitelist. This enab
 
 Use `PEERPORT` to specify the port(s) Transmission should listen on.  This disables random port selection.  This should be the same as the port mapped in your docker configuration.
 
+## Use alternative Transmission folder paths
+
+Use `COMPLETE_PATH` to specify a custom path for completed downloads.
+
+Use `INCOMPLETE_PATH` to specify a custom path for in-progress downloads.
+
 ## Usage
 
 To help you get started creating a container from this image you can either use docker-compose or the docker cli.
@@ -106,6 +112,8 @@ services:
       - WHITELIST= #optional
       - PEERPORT= #optional
       - HOST_WHITELIST= #optional
+      - COMPLETE_PATH=/downloads/complete #optional
+      - INCOMPLETE_PATH=/downloads/incomplete #optional
     volumes:
       - /path/to/data:/config
       - /path/to/downloads:/downloads
@@ -131,6 +139,8 @@ docker run -d \
   -e WHITELIST= `#optional` \
   -e PEERPORT= `#optional` \
   -e HOST_WHITELIST= `#optional` \
+  -e COMPLETE_PATH=/downloads/complete `#optional` \
+  -e INCOMPLETE_PATH=/downloads/incomplete `#optional` \
   -p 9091:9091 \
   -p 51413:51413 \
   -p 51413:51413/udp \
@@ -159,6 +169,8 @@ Containers are configured using parameters passed at runtime (such as those abov
 | `-e WHITELIST=` | Specify an optional list of comma separated ip whitelist. Fills rpc-whitelist setting. |
 | `-e PEERPORT=` | Specify an optional port for torrent TCP/UDP connections. Fills peer-port setting. |
 | `-e HOST_WHITELIST=` | Specify an optional list of comma separated dns name whitelist. Fills rpc-host-whitelist setting. |
+| `-e COMPLETE_PATH=/downloads/complete` | Custom path for completed downloads |
+| `-e INCOMPLETE_PATH=/downloads/incomplete` | Custom path for incomplete downloads |
 | `-v /config` | Where transmission should store config files and logs. |
 | `-v /downloads` | Local path for downloads. |
 | `-v /watch` | Watch folder for torrent files. |

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -45,6 +45,8 @@ opt_param_env_vars:
   - { env_var: "WHITELIST", env_value: "", desc: "Specify an optional list of comma separated ip whitelist. Fills rpc-whitelist setting."}
   - { env_var: "PEERPORT", env_value: "", desc: "Specify an optional port for torrent TCP/UDP connections. Fills peer-port setting."}
   - { env_var: "HOST_WHITELIST", env_value: "", desc: "Specify an optional list of comma separated dns name whitelist. Fills rpc-host-whitelist setting."}
+  - { env_var: "COMPLETE_PATH", env_value: "/downloads/complete", desc: "Custom path for completed downloads" }
+  - { env_var: "INCOMPLETE_PATH", env_value: "/downloads/incomplete", desc: "Custom path for incomplete downloads" }
 opt_param_usage_include_vols: false
 opt_param_usage_include_ports: false
 opt_param_device_map: false
@@ -77,6 +79,12 @@ app_setup_block: |
   ## Use alternative Transmission torrent ports
   
   Use `PEERPORT` to specify the port(s) Transmission should listen on.  This disables random port selection.  This should be the same as the port mapped in your docker configuration.
+
+  ## Use alternative Transmission folder paths
+
+  Use `COMPLETE_PATH` to specify a custom path for completed downloads.
+
+  Use `INCOMPLETE_PATH` to specify a custom path for in-progress downloads.
 
 # changelog
 changelogs:

--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -1,14 +1,29 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-# make folders
-mkdir -p \
-    /downloads/{complete,incomplete} /watch
 
 # copy config
 if [[ ! -f /config/settings.json ]]; then
     cp /defaults/settings.json /config/settings.json
 fi
+
+# make folders, optionally set paths in config
+mkdir -p /watch
+
+INIT_COMPLETE_PATH="/downloads/complete"
+INIT_INCOMPLETE_PATH="/downloads/incomplete"
+
+if [[ -n "$COMPLETE_PATH" ]]; then
+    $INIT_COMPLETE_PATH="$COMPLETE_PATH"
+    sed -i "/\"download-dir\"/c\    \"download-dir\": \"$COMPLETE_PATH\"," /config/settings.json
+fi
+mkdir -p "$INIT_COMPLETE_PATH"
+
+if [[ -n "$INCOMPLETE_PATH" ]]; then
+    $INIT_INCOMPLETE_PATH="$INCOMPLETE_PATH"
+    sed -i "/\"incomplete-dir\"/c\    \"incomplete-dir\": \"$INCOMPLETE_PATH\"," /config/settings.json
+fi
+mkdir -p "$INIT_INCOMPLETE_PATH"
 
 if [[ -n "$USER" ]] && [[ -n "$PASS" ]]; then
     sed -i '/rpc-authentication-required/c\    "rpc-authentication-required": true,' /config/settings.json
@@ -53,12 +68,12 @@ if [[ "$(stat -c '%U' /downloads)" != "abc" ]]; then
     lsiown abc:abc /downloads
 fi
 
-if [[ "$(stat -c '%U' /downloads/complete)" != "abc" ]]; then
-    lsiown abc:abc /downloads/complete
+if [[ "$(stat -c '%U' "$INIT_COMPLETE_PATH")" != "abc" ]]; then
+    lsiown abc:abc "$INIT_COMPLETE_PATH"
 fi
 
-if [[ "$(stat -c '%U' /downloads/incomplete)" != "abc" ]]; then
-    lsiown abc:abc /downloads/incomplete
+if [[ "$(stat -c '%U' "$INIT_INCOMPLETE_PATH")" != "abc" ]]; then
+    lsiown abc:abc "$INIT_INCOMPLETE_PATH"
 fi
 
 if [[ "$(stat -c '%U' /watch)" != "abc" ]]; then

--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -14,13 +14,13 @@ INIT_COMPLETE_PATH="/downloads/complete"
 INIT_INCOMPLETE_PATH="/downloads/incomplete"
 
 if [[ -n "$COMPLETE_PATH" ]]; then
-    $INIT_COMPLETE_PATH="$COMPLETE_PATH"
+    INIT_COMPLETE_PATH="$COMPLETE_PATH"
     sed -i "/\"download-dir\"/c\    \"download-dir\": \"$COMPLETE_PATH\"," /config/settings.json
 fi
 mkdir -p "$INIT_COMPLETE_PATH"
 
 if [[ -n "$INCOMPLETE_PATH" ]]; then
-    $INIT_INCOMPLETE_PATH="$INCOMPLETE_PATH"
+    INIT_INCOMPLETE_PATH="$INCOMPLETE_PATH"
     sed -i "/\"incomplete-dir\"/c\    \"incomplete-dir\": \"$INCOMPLETE_PATH\"," /config/settings.json
 fi
 mkdir -p "$INIT_INCOMPLETE_PATH"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-transmission/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Currently the `complete` and `incomplete` download paths are hardcoded. When migrating a large transmission install to this container it is quite difficult to rewrite paths in Transmission's `.resume` files. This PR allows users to supply a custom path for `download-dir` and `incomplete-dir` to be used in the init script (creating/owning dirs) and writes the path to `settings.json`.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
I recently migrated a large (~2000 xfers) transmission environment from Ubuntu to this container. My existing download-dir is named `completed` and I would like to continue using that name without the complete dir interfering with my tab complete. The process of rewriting transmission's .resume files to match the complete naming convention is tedious and prone to errors.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Ran jenkins-builder!


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/linuxserver/docker-transmission/issues/265
https://github.com/linuxserver/docker-transmission/issues/256
