### PR TITLE
read download/incomplete directory paths from `settings.json`

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -1,11 +1,9 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-SETTINGS=/config/settings.json
-
 # copy config
-if [[ ! -f $SETTINGS ]]; then
-    cp /defaults/settings.json $SETTINGS
+if [[ ! -f /config/settings.json ]]; then
+    cp /defaults/settings.json /config/settings.json
 fi
 
 # Default values
@@ -13,11 +11,11 @@ DOWNLOAD_DIR="/downloads/complete"
 INCOMPLETE_DIR="/downloads/incomplete"
 
 # Check `settings.json` for custom download/incomplete directories
-settings_download_dir=$(grep -o '"download-dir": "[^"]*' "$SETTINGS" | sed 's/"download-dir": "//')
+settings_download_dir=$(jq -r '."download-dir" | select( . != null )' /config/settings.json)
 if [ ! -z "$settings_download_dir" ]; then
     DOWNLOAD_DIR="$settings_download_dir"
 fi
-settings_incomplete_dir=$(grep -o '"incomplete-dir": "[^"]*' "$SETTINGS" | sed 's/"incomplete-dir": "//')
+settings_incomplete_dir=$(jq -r '."incomplete-dir" | select( . != null )' /config/settings.json)
 if [ ! -z "$settings_incomplete_dir" ]; then
     INCOMPLETE_DIR="$settings_incomplete_dir"
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -1,14 +1,31 @@
 #!/usr/bin/with-contenv bash
 # shellcheck shell=bash
 
-# make folders
-mkdir -p \
-    /downloads/{complete,incomplete} /watch
+SETTINGS=/config/settings.json
 
 # copy config
-if [[ ! -f /config/settings.json ]]; then
-    cp /defaults/settings.json /config/settings.json
+if [[ ! -f $SETTINGS ]]; then
+    cp /defaults/settings.json $SETTINGS
 fi
+
+# Default values
+DOWNLOAD_DIR="/downloads/complete"
+INCOMPLETE_DIR="/downloads/incomplete"
+
+# Check `settings.json` for custom download/incomplete directories
+settings_download_dir=$(grep -o '"download-dir": "[^"]*' "$SETTINGS" | sed 's/"download-dir": "//')
+if [ ! -z "$settings_download_dir" ]; then
+    DOWNLOAD_DIR="$settings_download_dir"
+fi
+settings_incomplete_dir=$(grep -o '"incomplete-dir": "[^"]*' "$SETTINGS" | sed 's/"incomplete-dir": "//')
+if [ ! -z "$settings_incomplete_dir" ]; then
+    INCOMPLETE_DIR="$settings_incomplete_dir"
+fi
+
+# make folders
+mkdir -p $DOWNLOAD_DIR
+mkdir -p $INCOMPLETE_DIR
+mkdir -p /watch
 
 if [[ -n "$USER" ]] && [[ -n "$PASS" ]]; then
     sed -i '/rpc-authentication-required/c\    "rpc-authentication-required": true,' /config/settings.json
@@ -49,16 +66,16 @@ echo /transmissionic /combustion-release /flood-for-transmission /kettu /transmi
 lsiown abc:abc \
     /config/settings.json
 
-if [[ "$(stat -c '%U' /downloads)" != "abc" ]]; then
+if [[ -d /downloads && "$(stat -c '%U' /downloads)" != "abc" ]]; then
     lsiown abc:abc /downloads
 fi
 
-if [[ "$(stat -c '%U' /downloads/complete)" != "abc" ]]; then
-    lsiown abc:abc /downloads/complete
+if [[ "$(stat -c '%U' $DOWNLOAD_DIR)" != "abc" ]]; then
+    lsiown abc:abc $DOWNLOAD_DIR
 fi
 
-if [[ "$(stat -c '%U' /downloads/incomplete)" != "abc" ]]; then
-    lsiown abc:abc /downloads/incomplete
+if [[ "$(stat -c '%U' $INCOMPLETE_DIR)" != "abc" ]]; then
+    lsiown abc:abc $INCOMPLETE_DIR
 fi
 
 if [[ "$(stat -c '%U' /watch)" != "abc" ]]; then


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-transmission/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

This PR replaces hardcoded paths for directory creation/ownership with paths parsed from `settings.json`. If paths cannot be found in the file, defaults are used.

For standard installations, this change has no effect. In the case that a user sets a custom path for `download-dir` and/or `incomplete-dir` in `settings.json`, the run script will `mkdir`/`lsiown` the custom directories instead of the defaults.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

Currently, even if a user changes the path(s) of `download-dir`/`incomplete-dir` in `settings.json`, the run script will still `mkdir`/`lsiown` the default directories (`/downloads/complete` & `/downloads/incomplete`) every time the container starts. Although these unused directories don't pose any serious issue, they can be a nuisance when navigating with autocomplete in the command line.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Ran jenkins-builder.

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
https://github.com/linuxserver/docker-transmission/issues/265
https://github.com/linuxserver/docker-transmission/issues/256
https://github.com/linuxserver/docker-transmission/pull/266

