### PR TITLE
Forced `umask` to be a string.

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -42,7 +42,7 @@ if [[ -n "${PEERPORT}" ]]; then
 fi
 
 if [[ -n "${UMASK}" ]]; then
-    sed -i "/\"umask\"/c\    \"umask\": ${UMASK}," /config/settings.json
+    sed -i "/\"umask\"/c\    \"umask\": \"${UMASK}\"," /config/settings.json
 fi
 
 # Handle old theme locations


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-transmission/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->

`umask`, while a number, should be treated as a string in the JSON file. My previous PR failed to address it.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->

It will fix #292 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

The current code works when `umask` is quoted. This PR uses the unquoted string, and quotes it in the code.
It worked for me running locally.


## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->

The relevant issue is #292.
