### PR TITLE
Fixing file exists messages

### DIFF
--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -37,18 +37,6 @@ if [[ -n "${UMASK}" ]]; then
     echo -E "$(jq -r --arg umask "${UMASK}" '.["umask"] = $umask' /config/settings.json)" >/config/settings.json
 fi
 
-if [[ -z ${LSIO_NON_ROOT_USER} ]] && [[ -z ${LSIO_READ_ONLY_FS} ]]; then
-    # Handle old theme locations
-    declare -a theme_dirs=("transmissionic" "combustion-release" "flood-for-transmission" "kettu" "transmission-web-control")
-    
-    for dir in "${theme_dirs[@]}"; do
-        mkdir -p "/$dir"
-        if [[ ! -f "/$dir/index.html" ]] && [[ ! -L "/$dir/index.html" ]]; then
-            ln -s "/defaults/index.html" "/$dir/index.html"
-        fi
-    done
-fi
-
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     lsiown -R abc:abc \
         /config

--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -38,9 +38,15 @@ if [[ -n "${UMASK}" ]]; then
 fi
 
 if [[ -z ${LSIO_NON_ROOT_USER} ]] && [[ -z ${LSIO_READ_ONLY_FS} ]]; then
-    # Handle old theme locations
-    mkdir -p {/transmissionic,/combustion-release,/flood-for-transmission,/kettu,/transmission-web-control}
-    echo /transmissionic /combustion-release /flood-for-transmission /kettu /transmission-web-control | xargs -n1 ln -sf /defaults/index.html
+    # Handle old theme locations
+    declare -a theme_dirs=("transmissionic" "combustion-release" "flood-for-transmission" "kettu" "transmission-web-control")
+    
+    for dir in "${theme_dirs[@]}"; do
+        mkdir -p "/$dir"
+        if [[ ! -f "/$dir/index.html" ]] && [[ ! -L "/$dir/index.html" ]]; then
+            ln -s "/defaults/index.html" "/$dir/index.html"
+        fi
+    done
 fi
 
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then

--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -40,7 +40,7 @@ fi
 if [[ -z ${LSIO_NON_ROOT_USER} ]] && [[ -z ${LSIO_READ_ONLY_FS} ]]; then
     # Handle old theme locations
     mkdir -p {/transmissionic,/combustion-release,/flood-for-transmission,/kettu,/transmission-web-control}
-    echo /transmissionic /combustion-release /flood-for-transmission /kettu /transmission-web-control | xargs -n1 ln -s /defaults/index.html
+    echo /transmissionic /combustion-release /flood-for-transmission /kettu /transmission-web-control | xargs -n1 ln -sf /defaults/index.html
 fi
 
 if [[ -z ${LSIO_NON_ROOT_USER} ]]; then


### PR DESCRIPTION
Fixes:
```
transmission  | ln: failed to create symbolic link '/transmissionic/index.html': File exists
transmission  | ln: failed to create symbolic link '/combustion-release/index.html': File exists
transmission  | ln: failed to create symbolic link '/flood-for-transmission/index.html': File exists
transmission  | ln: failed to create symbolic link '/kettu/index.html': File exists
transmission  | ln: failed to create symbolic link '/transmission-web-control/index.html': File exists
```