### PR TITLE
fix: read directory paths from settings.json instead of hardcoding

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -106,6 +106,7 @@ init_diagram: |
   "transmission:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "04.04.26:", desc: "Read download, incomplete, and watch directory paths from settings.json instead of hardcoding them in init script."}
   - {date: "29.11.24:", desc: "Fix PEERPORT setting."}
   - {date: "07.10.23:", desc: "Install unrar from [linuxserver repo](https://github.com/linuxserver/docker-unrar)."}
   - {date: "10.08.23:", desc: "Bump unrar to 6.2.10."}

--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -107,6 +107,7 @@ init_diagram: |
 # changelog
 changelogs:
   - {date: "31.05.26:", desc: "Bind RPC to IPv6 interface by default, fall back to IPv4 if unavailable."}
+  - {date: "04.04.26:", desc: "Read download, incomplete, and watch directory paths from settings.json instead of hardcoding them in init script."}
   - {date: "29.11.24:", desc: "Fix PEERPORT setting."}
   - {date: "07.10.23:", desc: "Install unrar from [linuxserver repo](https://github.com/linuxserver/docker-unrar)."}
   - {date: "10.08.23:", desc: "Bump unrar to 6.2.10."}

--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -47,23 +47,29 @@ if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     lsiown -R abc:abc \
         /config
 
-    if grep -qe ' /downloads ' /proc/mounts; then
-        if [[ "$(stat -c '%U' /downloads)" != "abc" ]]; then
-            lsiown abc:abc /downloads
-        fi
-
-        if [[ "$(stat -c '%U' /downloads/complete)" != "abc" ]]; then
-            lsiown abc:abc /downloads/complete
-        fi
-
-        if [[ "$(stat -c '%U' /downloads/incomplete)" != "abc" ]]; then
-            lsiown abc:abc /downloads/incomplete
-        fi
+    if [[ -f /config/settings.json ]]; then
+        DOWNLOAD_DIR=$(jq -r '.["download-dir"] // "/downloads"' /config/settings.json)
+        INCOMPLETE_DIR=$(jq -r '.["incomplete-dir"] // "/downloads/incomplete"' /config/settings.json)
+        INCOMPLETE_ENABLED=$(jq -r '.["incomplete-dir-enabled"] // false' /config/settings.json)
+        WATCH_DIR=$(jq -r '.["watch-dir"] // "/watch"' /config/settings.json)
+        WATCH_ENABLED=$(jq -r '.["watch-dir-enabled"] // false' /config/settings.json)
+    else
+        DOWNLOAD_DIR="/downloads"
+        INCOMPLETE_DIR="/downloads/incomplete"
+        INCOMPLETE_ENABLED="true"
+        WATCH_DIR="/watch"
+        WATCH_ENABLED="true"
     fi
 
-    if grep -qe ' /watch ' /proc/mounts; then
-        if [[ "$(stat -c '%U' /watch)" != "abc" ]]; then
-            lsiown abc:abc /watch
-        fi
+    if [[ -d "${DOWNLOAD_DIR}" ]] && [[ "$(stat -c '%U' "${DOWNLOAD_DIR}")" != "abc" ]]; then
+        lsiown abc:abc "${DOWNLOAD_DIR}"
+    fi
+
+    if [[ "${INCOMPLETE_ENABLED}" == "true" ]] && [[ -d "${INCOMPLETE_DIR}" ]] && [[ "$(stat -c '%U' "${INCOMPLETE_DIR}")" != "abc" ]]; then
+        lsiown abc:abc "${INCOMPLETE_DIR}"
+    fi
+
+    if [[ "${WATCH_ENABLED}" == "true" ]] && [[ -d "${WATCH_DIR}" ]] && [[ "$(stat -c '%U' "${WATCH_DIR}")" != "abc" ]]; then
+        lsiown abc:abc "${WATCH_DIR}"
     fi
 fi

--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -51,23 +51,29 @@ if [[ -z ${LSIO_NON_ROOT_USER} ]]; then
     lsiown -R abc:abc \
         /config
 
-    if grep -qe ' /downloads ' /proc/mounts; then
-        if [[ "$(stat -c '%U' /downloads)" != "abc" ]]; then
-            lsiown abc:abc /downloads
-        fi
-
-        if [[ "$(stat -c '%U' /downloads/complete)" != "abc" ]]; then
-            lsiown abc:abc /downloads/complete
-        fi
-
-        if [[ "$(stat -c '%U' /downloads/incomplete)" != "abc" ]]; then
-            lsiown abc:abc /downloads/incomplete
-        fi
+    if [[ -f /config/settings.json ]]; then
+        DOWNLOAD_DIR=$(jq -r '.["download-dir"] // "/downloads"' /config/settings.json)
+        INCOMPLETE_DIR=$(jq -r '.["incomplete-dir"] // "/downloads/incomplete"' /config/settings.json)
+        INCOMPLETE_ENABLED=$(jq -r '.["incomplete-dir-enabled"] // false' /config/settings.json)
+        WATCH_DIR=$(jq -r '.["watch-dir"] // "/watch"' /config/settings.json)
+        WATCH_ENABLED=$(jq -r '.["watch-dir-enabled"] // false' /config/settings.json)
+    else
+        DOWNLOAD_DIR="/downloads"
+        INCOMPLETE_DIR="/downloads/incomplete"
+        INCOMPLETE_ENABLED="true"
+        WATCH_DIR="/watch"
+        WATCH_ENABLED="true"
     fi
 
-    if grep -qe ' /watch ' /proc/mounts; then
-        if [[ "$(stat -c '%U' /watch)" != "abc" ]]; then
-            lsiown abc:abc /watch
-        fi
+    if [[ -d "${DOWNLOAD_DIR}" ]] && [[ "$(stat -c '%U' "${DOWNLOAD_DIR}")" != "abc" ]]; then
+        lsiown abc:abc "${DOWNLOAD_DIR}"
+    fi
+
+    if [[ "${INCOMPLETE_ENABLED}" == "true" ]] && [[ -d "${INCOMPLETE_DIR}" ]] && [[ "$(stat -c '%U' "${INCOMPLETE_DIR}")" != "abc" ]]; then
+        lsiown abc:abc "${INCOMPLETE_DIR}"
+    fi
+
+    if [[ "${WATCH_ENABLED}" == "true" ]] && [[ -d "${WATCH_DIR}" ]] && [[ "$(stat -c '%U' "${WATCH_DIR}")" != "abc" ]]; then
+        lsiown abc:abc "${WATCH_DIR}"
     fi
 fi


### PR DESCRIPTION
------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-transmission/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

## Description:

The init script reads `download-dir`, `incomplete-dir`, and `watch-dir` from `settings.json` using `jq` (already a dependency in the same script) instead of hardcoding `/downloads/complete` and `/downloads/incomplete`.

Ownership checks for `incomplete-dir` and `watch-dir` are now conditional on their respective `*-enabled` flags in `settings.json`.

Falls back to default paths (`/downloads`, `/downloads/incomplete`, `/watch`) when `settings.json` does not exist yet (first start).

## Benefits of this PR and context:

The current init script hardcodes `/downloads/complete` and `/downloads/incomplete` paths for ownership checks. When users configure different paths in `settings.json` (or disable these features entirely), the script produces `stat: cannot statx` errors on every container start.

This change respects user configuration while preserving the original ownership-fixing behavior for users who keep the default paths.

Closes #34, closes #164

## How Has This Been Tested?

- Container start with default `settings.json` (default paths) — ownership set correctly
- Container start with `incomplete-dir-enabled: false` and no `complete`/`incomplete` directories — no errors
- Container start with custom `download-dir` path — ownership set on the correct directory
- Container start without `settings.json` (first run) — falls back to default paths

## Source / References:

- #34 — Request to use single `/download` directory
- #164 — Permission errors with hardcoded directories