### PR TITLE
Change rpc-bind-address to use dualstack and add DISABLE_IPV6 var

### DIFF
--- a/readme-vars.yml
+++ b/readme-vars.yml
@@ -34,6 +34,7 @@ opt_param_env_vars:
   - {env_var: "PASS", env_value: "", desc: "Specify an optional password for the interface"}
   - {env_var: "WHITELIST", env_value: "", desc: "Specify an optional list of comma separated ip whitelist. Fills rpc-whitelist setting."}
   - {env_var: "PEERPORT", env_value: "", desc: "Specify an optional port for torrent TCP/UDP connections. Fills peer-port setting."}
+  - {env_var: "DISABLE_IPV6", env_value: "", desc: "Changes setting rpc-bind-address to IPv4 only."}
   - {env_var: "HOST_WHITELIST", env_value: "", desc: "Specify an optional list of comma separated dns name whitelist. Fills rpc-host-whitelist setting."}
 readonly_supported: true
 nonroot_supported: true
@@ -106,6 +107,7 @@ init_diagram: |
   "transmission:latest" <- Base Images
 # changelog
 changelogs:
+  - {date: "30.04.26:", desc: "Change rpc-bind-address to dualstack."}
   - {date: "29.11.24:", desc: "Fix PEERPORT setting."}
   - {date: "07.10.23:", desc: "Install unrar from [linuxserver repo](https://github.com/linuxserver/docker-unrar)."}
   - {date: "10.08.23:", desc: "Bump unrar to 6.2.10."}

--- a/root/defaults/settings.json
+++ b/root/defaults/settings.json
@@ -41,7 +41,7 @@
     "ratio-limit-enabled": false,
     "rename-partial-files": true,
     "rpc-authentication-required": false,
-    "rpc-bind-address": "0.0.0.0",
+    "rpc-bind-address": "[::]",
     "rpc-enabled": true,
     "rpc-password": "{1ddd3f1f6a71d655cde7767242a23a575b44c909n5YuRT.f",
     "rpc-port": 9091,

--- a/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
+++ b/root/etc/s6-overlay/s6-rc.d/init-transmission-config/run
@@ -33,6 +33,10 @@ if [[ -n "${PEERPORT}" ]]; then
     echo -E "$(jq -r '.["peer-port-random-on-start"] = false' /config/settings.json)" >/config/settings.json
 fi
 
+if [[ "${DISABLE_IPV6}" == "true" ]]; then
+    echo -E "$(jq -r '.["rpc-bind-address"] = "0.0.0.0"' /config/settings.json)" > /config/settings.json
+fi
+
 if [[ -n "${UMASK}" ]]; then
     echo -E "$(jq -r --arg umask "${UMASK}" '.["umask"] = $umask' /config/settings.json)" >/config/settings.json
 fi


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

[linuxserverurl]: https://linuxserver.io
[![linuxserver.io](https://raw.githubusercontent.com/linuxserver/docker-templates/master/linuxserver.io/img/linuxserver_medium.png)][linuxserverurl]


<!--- Before submitting a pull request please check the following -->

<!---  If this is a fix for a typo (in code, documentation, or the README) please file an issue and let us sort it out. We do not need a PR  -->
<!---  Ask yourself if this modification is something the whole userbase will benefit from, if this is a specific change for corner case functionality or plugins please look at making a Docker Mod or local script  https://blog.linuxserver.io/2019/09/14/customizing-our-containers/ -->
<!---  That if the PR is addressing an existing issue include, closes #<issue number> , in the body of the PR commit message   -->
<!---  You have included links to any files / patches etc your PR may be using in the body of the PR commit message -->
<!--- We maintain a changelog of major revisions to the container at the end of readme-vars.yml in the root of this repository, please add your changes there if appropriate -->


<!--- Coding guidelines: -->
<!--- 1. Installed packages in the Dockerfiles should be in alphabetical order -->
<!--- 2. Changes to Dockerfile should be replicated in Dockerfile.armhf and Dockerfile.aarch64 if applicable -->
<!--- 3. Indentation style (tabs vs 4 spaces vs 1 space) should match the rest of the document -->
<!--- 4. Readme is auto generated from readme-vars.yml, make your changes there -->

------------------------------

 - [x] I have read the [contributing](https://github.com/linuxserver/docker-transmission/blob/master/.github/CONTRIBUTING.md) guideline and understand that I have made the correct modifications

------------------------------

<!--- We welcome all PR’s though this doesn’t guarantee it will be accepted. -->

## Description:
<!--- Describe your changes in detail -->
Change rpc-bind-address setting to dual stack mode. Additionally add `DISABLE_IPV6` env variable for people who have disabled IPv6 via kernel settings.

## Benefits of this PR and context:
<!--- Please explain why we should accept this PR. If this fixes an outstanding bug, please reference the issue # -->
This makes the docker image usable on IPv6 only hosts and additionally, will solve issues for some people who uses the localhost URL.

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
IPv6 only tested and working.
Tested that it binds to both protocols, from the single setting.
Tested the new env variable change to settings.json correctly

## Source / References:
<!--- Please include any forum posts/github links relevant to the PR -->
